### PR TITLE
Makefile: Correct name of rst2man program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ OBJS = $(ALL_CSRCS:.c=.o)
 all: $(TARGETS)
 
 dis6502.1: dis.rst
-	rst2man.py dis.rst >$@
+	rst2man dis.rst >$@
 dis6502.man: dis6502.1
 	nroff -man dis6502.1 >$@
 


### PR DESCRIPTION
This was previously called as `rst2man.py`, suggesting that there was some strange install of this being used. Whether installed via `pip install docutils` or `apt install python3-docutils`, the program is actually called just `rst2man`.